### PR TITLE
Restrição de configuração CORS 

### DIFF
--- a/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/controller/AdvantageController.java
+++ b/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/controller/AdvantageController.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,7 +26,6 @@ import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/advantages")
-@CrossOrigin(origins = "*")
 public class AdvantageController {
     
     @Autowired

--- a/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/controller/CompanyController.java
+++ b/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/controller/CompanyController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/company")
-@CrossOrigin(origins = "*")
 public class CompanyController {
     
     @Autowired

--- a/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/controller/InstitutionController.java
+++ b/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/controller/InstitutionController.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,7 +14,6 @@ import com.moedaestudantil.repository.InstitutionRepository;
 
 @RestController
 @RequestMapping("/api/institutions")
-@CrossOrigin(origins = "*")
 public class InstitutionController {
     
     @Autowired

--- a/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/controller/ProfessorActionsController.java
+++ b/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/controller/ProfessorActionsController.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,7 +25,6 @@ import com.moedaestudantil.repository.TransactionRepository;
 
 @RestController
 @RequestMapping("/api/professor")
-@CrossOrigin(origins = "*")
 public class ProfessorActionsController {
 
     @Autowired

--- a/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/controller/ProfessorController.java
+++ b/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/controller/ProfessorController.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,7 +24,6 @@ import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/professors")
-@CrossOrigin(origins = "*")
 public class ProfessorController {
 
     @Autowired

--- a/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/controller/StudentController.java
+++ b/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/controller/StudentController.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -33,7 +32,6 @@ import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/students")
-@CrossOrigin(origins = "*")
 public class StudentController {
     
     @Autowired

--- a/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/dto/AdvantageRequest.java
+++ b/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/dto/AdvantageRequest.java
@@ -3,7 +3,6 @@ package com.moedaestudantil.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import java.util.UUID;
 
 public class AdvantageRequest {
     

--- a/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/dto/RedemptionRequest.java
+++ b/MoedaEstudantil/Backend/src/main/java/com/moedaestudantil/dto/RedemptionRequest.java
@@ -3,7 +3,6 @@ package com.moedaestudantil.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.util.UUID;
 
 public class RedemptionRequest {
     


### PR DESCRIPTION
*corrigido configuracao CORS crossOrigin

✔ Tipo de refatoração aplicada:
- Removido anotações 'CrossOrigin' que efetuavam override dentre a configuração CORS criada no projeto.
- Removido também imports inutilizados nas classes relacionadas.

📝 Justificativa:
Não faz sentido criar uma CORSConfig se ela vai acabar sendo dispensada em cada uma das classes utilizadas, é melhor configurá-la neste arquivo em vez de setar suas origins em cada classe manualmente.

**_TODO_**:
Limitar o acesso concedido do CORS para discernir administrador e usuário.
Do jeito como está qualquer usuário poderia efetuar comandos back-end para alterar seu saldo por exemplo, desde que sua origem seja 'https://lab-projeto-de-software-fblexrfoz.vercel.app'.